### PR TITLE
AUTH-5098-fix-secrets-type-description-validation

### DIFF
--- a/secret_server_provider/transformers/folders_transformer.py
+++ b/secret_server_provider/transformers/folders_transformer.py
@@ -33,5 +33,4 @@ class FoldersTransformer(BaseTransformer):
                 targetId=normalize_id(raw_item.id),
             )
             bundle.new_assets_inheritance.append(inheritance)
-
         return bundle

--- a/secret_server_provider/transformers/secrets_last_access_key_transformer.py
+++ b/secret_server_provider/transformers/secrets_last_access_key_transformer.py
@@ -24,7 +24,8 @@ class SecretsLastAccessKeyTransformer(BaseTransformer):
             name=f"{field_name}: {access_key_records['itemValueNew']}",
             description=access_key_records['itemValueNew'],
             # TODO need new type 'access_key" and "secret_key"
-            type=AssetType.Other,
+            type=AssetType.File,
+            originType=field_name,
         )
         bundle.new_assets.append(asset)
         inheritance = NewAssetInheritanceRequestSchema(

--- a/secret_server_provider/transformers/secrets_transformer.py
+++ b/secret_server_provider/transformers/secrets_transformer.py
@@ -1,4 +1,8 @@
-from authomize.rest_api_client.generated.schemas import NewAssetRequestSchema, RequestsBundleSchema
+from authomize.rest_api_client.generated.schemas import (
+    AssetType,
+    NewAssetRequestSchema,
+    RequestsBundleSchema,
+)
 from secret_server_openapiclient.model.secret_summary import SecretSummary
 
 from base_provider.transformers.base_transformer import BaseTransformer
@@ -22,6 +26,8 @@ class SecretsTransformer(BaseTransformer):
             lastUsedAt=raw_item.last_accessed,
             # storing the template name as description
             description=raw_item.secret_template_name,
+            type=AssetType.File,
+            originType="Secret",
 
         )
         bundle.new_assets.append(asset)


### PR DESCRIPTION
new validation mechanism demands for AssetType file or folder to have description
