### PR TITLE
Auth 6012 password and user based authentication

### DIFF
--- a/mock_provider/examples/flow.py
+++ b/mock_provider/examples/flow.py
@@ -1,10 +1,9 @@
+from base_provider.configuration.application_configuration import ApplicationConfiguration
+from base_provider.configuration.authomize_api_configuration import AuthomizeApiConfiguration
 from onelogin_provider.configuration.client_configuration import OneloginClientConfiguration
 from onelogin_provider.configuration.shared_configuration import OneloginSharedConfiguration
 from onelogin_provider.workflows.health_checker import OneloginHealthChecker
 from onelogin_provider.workflows.runner import OneloginRunner
-
-from base_provider.configuration.application_configuration import ApplicationConfiguration
-from base_provider.configuration.authomize_api_configuration import AuthomizeApiConfiguration
 
 
 def example():

--- a/secret_server_provider/clients/secret_server_client.py
+++ b/secret_server_provider/clients/secret_server_client.py
@@ -11,8 +11,9 @@ class SecretServerClient(BaseClient):
         client_configuration: SecretServerConfiguration,
     ) -> None:
         super().__init__(client_configuration=client_configuration)
-        configuration = Configuration(host=client_configuration.host)
-        configuration.api_key['BearerToken'] = f'bearer {client_configuration.api_key}'
+        client_configuration.generate_authentication_token()
+        configuration = Configuration(host=client_configuration.api_host)
+        configuration.api_key['BearerToken'] = client_configuration.api_key
         # openapi client needs this
         self.configuration = configuration
         self.openapi_client = ApiClient(configuration=configuration)

--- a/secret_server_provider/clients/secret_server_client.py
+++ b/secret_server_provider/clients/secret_server_client.py
@@ -1,5 +1,5 @@
 from secret_server_openapiclient import ApiClient, Configuration
-
+import requests
 from base_provider.clients.base_client import BaseClient
 from secret_server_provider.clients.simple_http_client import SimpleHttpClient
 from secret_server_provider.configuration.client_configuration import SecretServerConfiguration
@@ -11,10 +11,25 @@ class SecretServerClient(BaseClient):
         client_configuration: SecretServerConfiguration,
     ) -> None:
         super().__init__(client_configuration=client_configuration)
-        client_configuration.generate_authentication_token()
+        self.generate_authentication_token_and_update_configuration()
         configuration = Configuration(host=client_configuration.api_host)
         configuration.api_key['BearerToken'] = client_configuration.api_key
         # openapi client needs this
         self.configuration = configuration
         self.openapi_client = ApiClient(configuration=configuration)
         self.internal_api_client = SimpleHttpClient(client_configuration)
+
+    def generate_authentication_token_and_update_configuration(self):
+        if (self.client_configuration.api_key == ""):
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            data = {"username": "AuthomizeUser",
+                    "grant_type": "password",
+                    "password": "Authomize123!",
+                    }
+            url = f'{self.client_configuration.api_host}/oauth2/token'
+            response = requests.post(url, headers=headers, data=data)
+            response.raise_for_status()
+            bearer_token = response.json()['access_token']
+            # shared with http_simple_client for internal api and external api querying
+            self.client_configuration.set_new_host(f'{self.client_configuration.api_host}/api')
+            self.client_configuration.set_api_key(f'bearer {bearer_token}')

--- a/secret_server_provider/clients/secret_server_client.py
+++ b/secret_server_provider/clients/secret_server_client.py
@@ -1,5 +1,6 @@
-from secret_server_openapiclient import ApiClient, Configuration
 import requests
+from secret_server_openapiclient import ApiClient, Configuration
+
 from base_provider.clients.base_client import BaseClient
 from secret_server_provider.clients.simple_http_client import SimpleHttpClient
 from secret_server_provider.configuration.client_configuration import SecretServerConfiguration

--- a/secret_server_provider/clients/simple_http_client.py
+++ b/secret_server_provider/clients/simple_http_client.py
@@ -8,11 +8,12 @@ class SimpleHttpClient(BaseClient):
     def __init__(
         self,
         client_configuration: SecretServerConfiguration,
+        api_key: str,
     ) -> None:
         super().__init__(client_configuration=client_configuration)
         self.headers = {
             "Content-Type": "application/json",
-            "Authorization": client_configuration.api_key,
+            "Authorization": api_key,
         }
         self.url = "https://integrations.secretservercloud.com/internals"
 

--- a/secret_server_provider/clients/simple_http_client.py
+++ b/secret_server_provider/clients/simple_http_client.py
@@ -12,7 +12,7 @@ class SimpleHttpClient(BaseClient):
         super().__init__(client_configuration=client_configuration)
         self.headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {client_configuration.api_key}",
+            "Authorization": client_configuration.api_key,
         }
         self.url = "https://integrations.secretservercloud.com/internals"
 

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import Field
 
 from base_provider.configuration.base_client_configuration import BaseClientConfiguration
@@ -7,14 +9,13 @@ class SecretServerConfiguration(BaseClientConfiguration):
     api_host: str = Field(..., env="SECRET_SERVER_HOST")
     user_name: str = Field(..., env="SECRET_SERVER_USERNAME")
     password: str = Field(..., env="SECRET_SERVER_PASSWORD")
-    # pass empty string if no extra fields or list of fields
     # access-key and username are by default fetched
-    keys_to_fetch: str = Field(..., env="KEY_FIELD_NAMES")
+    keys_to_fetch: Optional[str] = Field(default="access-key,username", env="KEY_FIELD_NAMES")
     api_key: str = ""
 
     # shared cofiguration api_key needs to be updated after token generation
     # for a sake of the http_simple_client who uses token for internal api queries
-    def set_api_key (self, new_key):
+    def set_api_key(self, new_key):
         self.api_key = new_key
 
     def set_new_host(self, new_host):

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -11,6 +11,8 @@ class SecretServerConfiguration(BaseClientConfiguration):
     api_host: str = Field(..., env="SECRET_SERVER_HOST")
     user_name: str = Field(..., env="SECRET_SERVER_USERNAME")
     password: str = Field(..., env="SECRET_SERVER_PASSWORD")
+    # pass empty string if no extra fields or list of fields
+    # access-key and username are by default fetched
     keys_to_fetch: str = Field(..., env="KEY_FIELD_NAMES")
     api_key: str = ""
 

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -1,13 +1,9 @@
-import requests
 from pydantic import Field
 
 from base_provider.configuration.base_client_configuration import BaseClientConfiguration
 
 
 class SecretServerConfiguration(BaseClientConfiguration):
-    # TODO : add default like host: str = Field(..., env="SECRET_SERVER_HOST",
-    #        default="https://integrations.secretservercloud.com/api")
-
     api_host: str = Field(..., env="SECRET_SERVER_HOST")
     user_name: str = Field(..., env="SECRET_SERVER_USERNAME")
     password: str = Field(..., env="SECRET_SERVER_PASSWORD")
@@ -16,16 +12,10 @@ class SecretServerConfiguration(BaseClientConfiguration):
     keys_to_fetch: str = Field(..., env="KEY_FIELD_NAMES")
     api_key: str = ""
 
-    def generate_authentication_token(self):
-        if (self.api_key == ""):
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            data = {"username": "AuthomizeUser",
-                    "grant_type": "password",
-                    "password": "Authomize123!",
-                    }
-            url = f'{self.api_host}/oauth2/token'
-            self.api_host = f'{self.api_host}/api'
-            response = requests.post(url, headers=headers, data=data)
-            response.raise_for_status()
-            bearer_token = response.json()['access_token']
-            self.api_key = f'bearer {bearer_token}'
+    # shared cofiguration api_key needs to be updated after token generation
+    # for a sake of the http_simple_client who uses token for internal api queries
+    def set_api_key (self, new_key):
+        self.api_key = new_key
+
+    def set_new_host(self, new_host):
+        self.api_host = new_host

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -11,12 +11,3 @@ class SecretServerConfiguration(BaseClientConfiguration):
     password: str = Field(..., env="SECRET_SERVER_PASSWORD")
     # access-key and username are by default fetched
     keys_to_fetch: Optional[str] = Field(default="access-key,username", env="KEY_FIELD_NAMES")
-    api_key: str = ""
-
-    # shared cofiguration api_key needs to be updated after token generation
-    # for a sake of the http_simple_client who uses token for internal api queries
-    def set_api_key(self, new_key):
-        self.api_key = new_key
-
-    def set_new_host(self, new_host):
-        self.api_host = new_host

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -1,5 +1,5 @@
-from pydantic import Field
 import requests
+from pydantic import Field
 
 from base_provider.configuration.base_client_configuration import BaseClientConfiguration
 
@@ -7,7 +7,7 @@ from base_provider.configuration.base_client_configuration import BaseClientConf
 class SecretServerConfiguration(BaseClientConfiguration):
     # TODO : add default like host: str = Field(..., env="SECRET_SERVER_HOST",
     #        default="https://integrations.secretservercloud.com/api")
- 
+
     api_host: str = Field(..., env="SECRET_SERVER_HOST")
     user_name: str = Field(..., env="SECRET_SERVER_USERNAME")
     password: str = Field(..., env="SECRET_SERVER_PASSWORD")
@@ -17,7 +17,10 @@ class SecretServerConfiguration(BaseClientConfiguration):
     def generate_authentication_token(self):
         if (self.api_key == ""):
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            data = {"username": "AuthomizeUser","grant_type": "password","password":"Authomize123!"}
+            data = {"username": "AuthomizeUser",
+                    "grant_type": "password",
+                    "password": "Authomize123!",
+                    }
             url = f'{self.api_host}/oauth2/token'
             self.api_host = f'{self.api_host}/api'
             response = requests.post(url, headers=headers, data=data)

--- a/secret_server_provider/configuration/client_configuration.py
+++ b/secret_server_provider/configuration/client_configuration.py
@@ -1,4 +1,5 @@
 from pydantic import Field
+import requests
 
 from base_provider.configuration.base_client_configuration import BaseClientConfiguration
 
@@ -6,6 +7,20 @@ from base_provider.configuration.base_client_configuration import BaseClientConf
 class SecretServerConfiguration(BaseClientConfiguration):
     # TODO : add default like host: str = Field(..., env="SECRET_SERVER_HOST",
     #        default="https://integrations.secretservercloud.com/api")
-    host: str = Field(..., env="SECRET_SERVER_HOST")
-    api_key: str = Field(..., env="SECRET_SERVER_API_KEY")
+ 
+    api_host: str = Field(..., env="SECRET_SERVER_HOST")
+    user_name: str = Field(..., env="SECRET_SERVER_USERNAME")
+    password: str = Field(..., env="SECRET_SERVER_PASSWORD")
     keys_to_fetch: str = Field(..., env="KEY_FIELD_NAMES")
+    api_key: str = ""
+
+    def generate_authentication_token(self):
+        if (self.api_key == ""):
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            data = {"username": "AuthomizeUser","grant_type": "password","password":"Authomize123!"}
+            url = f'{self.api_host}/oauth2/token'
+            self.api_host = f'{self.api_host}/api'
+            response = requests.post(url, headers=headers, data=data)
+            response.raise_for_status()
+            bearer_token = response.json()['access_token']
+            self.api_key = f'bearer {bearer_token}'

--- a/secret_server_provider/extractors/secrets_last_access_key_extractor.py
+++ b/secret_server_provider/extractors/secrets_last_access_key_extractor.py
@@ -44,7 +44,7 @@ class SecretsLastAccessKeyExtractor(BaseExtractor):
         # TODO read slug from secret's template
         data_provider_client: SecretServerClient = self.data_provider_client
         response = data_provider_client.internal_api_client.post_internal_api(
-            url_path=f'/secret-audits/{secret_id}/fields/{slug}',
+            url_path=f'secret-audits/{secret_id}/fields/{slug}',
         )
         try:
             response.raise_for_status()

--- a/secret_server_provider/extractors/secrets_last_access_key_extractor.py
+++ b/secret_server_provider/extractors/secrets_last_access_key_extractor.py
@@ -1,3 +1,4 @@
+from csv import field_size_limit
 from typing import Iterable
 
 from secret_server_openapiclient.apis import SecretsApi
@@ -23,15 +24,20 @@ class SecretsLastAccessKeyExtractor(BaseExtractor):
             "itemFileSize": null
     }
     """
-
+    predefined_interesting_keys = ["access-key", "username"]
     def extract_raw(self) -> Iterable[tuple[str, dict, str]]:
         data_provider_client: SecretServerClient = self.data_provider_client
         api_instance = SecretsApi(data_provider_client.openapi_client)
         all_secrets = get_paginated_results(api_instance.secrets_service_search_v2)
         for secret in all_secrets:
             normalized_secret_id = normalize_id(secret.id)
+            all_input_keys = []
             for field_key in data_provider_client.client_configuration.keys_to_fetch.split(','):
+                all_input_keys.append(field_key)
                 yield from self.get_records_by_slug(normalized_secret_id, field_key)
+            for field_key in self.predefined_interesting_keys:
+                if field_key not in all_input_keys:
+                    yield from self.get_records_by_slug(normalized_secret_id, field_key)
 
     def get_records_by_slug(self, secret_id: str, slug: str) -> Iterable[tuple[str, dict, str]]:
         key_history = self.get_secret_access_key_history(secret_id, slug)

--- a/secret_server_provider/extractors/secrets_last_access_key_extractor.py
+++ b/secret_server_provider/extractors/secrets_last_access_key_extractor.py
@@ -1,4 +1,3 @@
-from csv import field_size_limit
 from typing import Iterable
 
 from secret_server_openapiclient.apis import SecretsApi
@@ -24,7 +23,9 @@ class SecretsLastAccessKeyExtractor(BaseExtractor):
             "itemFileSize": null
     }
     """
+
     predefined_interesting_keys = ["access-key", "username"]
+
     def extract_raw(self) -> Iterable[tuple[str, dict, str]]:
         data_provider_client: SecretServerClient = self.data_provider_client
         api_instance = SecretsApi(data_provider_client.openapi_client)
@@ -32,9 +33,11 @@ class SecretsLastAccessKeyExtractor(BaseExtractor):
         for secret in all_secrets:
             normalized_secret_id = normalize_id(secret.id)
             all_input_keys = []
-            for field_key in data_provider_client.client_configuration.keys_to_fetch.split(','):
-                all_input_keys.append(field_key)
-                yield from self.get_records_by_slug(normalized_secret_id, field_key)
+            input_fields = data_provider_client.client_configuration.keys_to_fetch
+            if input_fields != '':
+                for field_key in input_fields.split(','):
+                    all_input_keys.append(field_key)
+                    yield from self.get_records_by_slug(normalized_secret_id, field_key)
             for field_key in self.predefined_interesting_keys:
                 if field_key not in all_input_keys:
                     yield from self.get_records_by_slug(normalized_secret_id, field_key)

--- a/secret_server_provider/extractors/users_extractor.py
+++ b/secret_server_provider/extractors/users_extractor.py
@@ -18,6 +18,4 @@ class UsersExtractor(BaseExtractor):
     def extract_raw(self) -> Iterable[UserSummary]:
         data_provider_client: SecretServerClient = self.data_provider_client
         api_instance = UsersApi(data_provider_client.openapi_client)
-        # paginated results
-        # return self.__get_paginated_results(api_instance)
         return get_paginated_results(api_instance.users_service_search_users)


### PR DESCRIPTION
1. no more secret server api token needed - we generate it from username and password
2. default key_field_names to get on them history in secrets are "access-key" and "username" (for AWS purpose)
The environment variable KEY_FIELD_NAMES can be either an empty string  or additional field names - both options are supported